### PR TITLE
Support video.js 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "test/"
   ],
   "peerDependencies": {
-    "video.js": "^7"
+    "video.js": "^7 || ^8"
   },
   "devDependencies": {
     "@babel/core": "^7.19.3",

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -41,7 +41,8 @@ const onPlayerReady = (player, options) => {
  */
 const vttThumbnails = function(options) {
   this.ready(() => {
-    onPlayerReady(this, videojs.mergeOptions(defaults, options));
+    const merge = videojs.obj?.merge || videojs.mergeOptions
+    onPlayerReady(this, merge(defaults, options));
   });
 };
 


### PR DESCRIPTION
video.js 8 deprecates the `videojs.mergeOptions` function in favour of `videojs.obj.merge`