### PR TITLE
Fix Object.hasOwn error

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -271,7 +271,7 @@ class vttThumbnailsPlugin {
     this.lastStyle = currentStyle;
 
     for (const style in currentStyle) {
-      if (currentStyle.hasOwn(style)) {
+      if (Object.hasOwn(currentStyle, style)) {
         this.thumbnailHolder.style[style] = currentStyle[style];
       }
     }


### PR DESCRIPTION
`Object.hasOwn` is a static function, so we can't use it like an instance method (results in an error about hasOwn not existing).

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn