### PR TITLE
Add support for data URLs

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -303,7 +303,7 @@ class vttThumbnailsPlugin {
   }
 
   getFullyQualifiedUrl(path, base) {
-    if (path.includes('//')) {
+    if (path.includes('//') || path.startsWith('data:')) {
       // We have a fully qualified path.
       return path;
     }


### PR DESCRIPTION
This will allow us to switch to using data URLs for the thumbnail VTT files (DASH manifest too) instead of writing them to the filesystem. That will fix the issues that we have with them not getting deleted afterwards and will also make it easier for FreeTubeCordova to support thumbnails with the local API.

https://developer.mozilla.org/en-US/docs/web/http/basics_of_http/data_urls